### PR TITLE
Prepare for crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "ippusb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chunked_transfer",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ippusb"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The ChromiumOS Authors"]
 edition = "2021"
 license = "BSD-3-Clause"
+description = "HTTP proxy for IPP-over-USB devices"
+repository = "https://github.com/google/ippusb"
 
 [dependencies]
 chunked_transfer = "1"


### PR DESCRIPTION
* Add missing manifest metadata.
* Increment version.
