### PR TITLE
Cleanup resources

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -183,6 +183,9 @@ impl Bridge {
             {
                 error!("Error serving HTTP connection: {}", http_err);
             }
+            if verbose {
+                debug!("Connection {} closed", client_num);
+            }
             Ok::<(), Error>(())
         });
     }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -162,6 +162,7 @@ impl Bridge {
             if let Err(http_err) = http1::Builder::new()
                 .title_case_headers(true)
                 .preserve_header_case(true)
+                .keep_alive(false)
                 .serve_connection(
                     stream,
                     service_fn(move |req| {

--- a/src/device.rs
+++ b/src/device.rs
@@ -273,7 +273,9 @@ impl InterfaceManager {
 
                         // If the device was unplugged, don't bother to print an error.  We're
                         // about to exit anyway.
-                        Err(Error::ReleaseInterface(_, rusb::Error::NoDevice)) => {}
+                        Err(Error::ReleaseInterface(_, rusb::Error::NoDevice)) => {
+                            break;
+                        }
 
                         // If this failed for some other reason, we're in some bad state.  There
                         // are no active interfaces, so restarting won't interrupt an active

--- a/src/http.rs
+++ b/src/http.rs
@@ -553,8 +553,13 @@ pub(crate) async fn handle_request(
 
     let mut builder = Response::builder().status(status);
     for (h, val) in headers.iter() {
+        // Don't pass through the printer's Connection header. Force it to Connection: close below.
+        if h == header::CONNECTION {
+            continue;
+        }
         builder = builder.header(h, val);
     }
+    builder = builder.header(header::CONNECTION, "close");
 
     debug!("* Forwarding printer response body");
     let (mut sender, body) = Body::channel();


### PR DESCRIPTION
This ensures the cleanup thread and HTTP server tasks are fully cleaned up when the last `Device` referring to a given `rusb::DeviceHandle` is dropped.

Fixes #4 

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
