### PR TITLE
Update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "ippusb"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chunked_transfer",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ippusb"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The ChromiumOS Authors"]
 edition = "2021"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This should be API compatible with the previous version, but increase the version to 0.4.0 instead of 0.3.2 because the Keep-Alive behavior changes are potentially noticeable to clients.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
