### PR TITLE
Prefer lowest-numbered interfaces

### DIFF
--- a/src/device_info.rs
+++ b/src/device_info.rs
@@ -43,7 +43,7 @@ pub fn device_supports_ippusb<T: UsbContext>(device: &rusb::Device<T>) -> Result
 /// The information for an interface descriptor that supports IPP-USB.
 ///
 /// Bulk transfers can be read/written to the in/out endpoints, respectively.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct IppusbDescriptor {
     pub interface_number: u8,
     pub alternate_setting: u8,
@@ -141,5 +141,48 @@ impl IppusbDeviceInfo {
         }
 
         Err(Error::NotIppUsb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The IppusbDescriptor tests just restate what the generated Ord implementation will do.  They
+    // are useful to capture the expectation that interface_number and alternate_setting are the
+    // most important sort fields even if somebody reorders the struct members.
+
+    #[test]
+    fn compare_lowest_interface_first() {
+        let lhs = IppusbDescriptor {
+            interface_number: 1,
+            alternate_setting: 1,
+            in_endpoint: 1,
+            out_endpoint: 2,
+        };
+        let rhs = IppusbDescriptor {
+            interface_number: 0,
+            alternate_setting: 2,
+            in_endpoint: 3,
+            out_endpoint: 4,
+        };
+        assert!(rhs < lhs);
+    }
+
+    #[test]
+    fn compare_lowest_alternate_first() {
+        let lhs = IppusbDescriptor {
+            interface_number: 1,
+            alternate_setting: 2,
+            in_endpoint: 1,
+            out_endpoint: 2,
+        };
+        let rhs = IppusbDescriptor {
+            interface_number: 1,
+            alternate_setting: 1,
+            in_endpoint: 3,
+            out_endpoint: 4,
+        };
+        assert!(rhs < lhs);
     }
 }


### PR DESCRIPTION
Currently, incoming requests are distributed across all available IPP-USB interfaces in order. The IPP-USB spec does not prescribe any particular order for using interfaces, so there is nothing conceptually wrong with this logic. However, some printers seem to be sensitive to the order in which interfaces are used.

By always using the lowest-numbered available interface, these printers seem happy without causing regressions in any of the other test devices in our lab.  This is achieved by switching out the VecDeque for a BinaryHeap with a custom Ord that prioritizes ClaimedInterface by lowest number.  Because BinaryHeap does not provide a non-consuming mutable iterator, the heap has to be rebuilt each time it is walked to claim or release interfaces.  This makes operations O(n*lg n) and O(lg n) instead of O(n) and O(1), but this shouldn't matter because a typical printer only has a couple of IPP-USB interfaces anyway.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
