### PR TITLE
Update version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "ippusb"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chunked_transfer",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ippusb"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The ChromiumOS Authors"]
 edition = "2021"
 license = "BSD-3-Clause"


### PR DESCRIPTION
There should be no API changes in this version, but increase the minor version since the underlying implementation affects which interface is chosen.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
