### PR TITLE
Increase MSRV to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "ippusb"
 version = "0.5.0"
 authors = ["The ChromiumOS Authors"]
 edition = "2021"
+rust-version = "1.89"
 license = "BSD-3-Clause"
 description = "HTTP proxy for IPP-over-USB devices"
 repository = "https://github.com/google/ippusb"

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -54,7 +54,7 @@ impl Bridge {
     /// called.
     ///
     /// * `verbose_log`: If true, log HTTP headers, additional info about HTTP bodies, and progress
-    ///    messages.
+    ///   messages.
     /// * `shutdown`: When this receives a value, stop processing new connections.
     /// * `listener`: A listening TCP socket for new incoming connections.
     /// * `usb`: An open device that supports IPP-USB.

--- a/src/device.rs
+++ b/src/device.rs
@@ -385,8 +385,7 @@ impl InterfaceManager {
         if let Some(handle) = cleanup_thread {
             let tid = handle.thread().id();
             handle.join().map_err(|_| {
-                Error::CleanupThread(io::Error::new(
-                    io::ErrorKind::Other,
+                Error::CleanupThread(io::Error::other(
                     "Failed to join cleanup thread",
                 ))
             })?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -120,8 +120,7 @@ where
                 for header in headers.iter().take_while(|&&h| h != httparse::EMPTY_HEADER) {
                     let name = HeaderName::from_bytes(header.name.as_bytes());
                     let val = HeaderValue::from_bytes(header.value);
-                    if name.is_ok() && val.is_ok() {
-                        let val = val.unwrap();
+                    if let (Ok(name), Ok(val)) = (name, val) {
                         if self.verbose_log {
                             debug!(
                                 "<  {}: {}",
@@ -129,7 +128,7 @@ where
                                 val.to_str().unwrap_or("Binary data")
                             );
                         }
-                        parsed_headers.append(name.unwrap(), val);
+                        parsed_headers.append(name, val);
                     } else {
                         error!(
                             "Ignoring malformed header {}:{:#?}",


### PR DESCRIPTION
This isn't strictly necessary, but it brings the package in sync with the rust version in current ChromeOS LTS.  Also clean up clippy lints from the newer rust version.