### PR TITLE
Switch to hyper 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,24 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,9 +94,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -117,12 +105,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -140,25 +140,38 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "pin-utils",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
- "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -166,8 +179,10 @@ name = "ippusb"
 version = "0.5.0"
 dependencies = [
  "chunked_transfer",
+ "http-body-util",
  "httparse",
  "hyper",
+ "hyper-util",
  "log",
  "rusb",
  "testing_logger",
@@ -240,12 +255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,37 +386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,15 +396,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/google/ippusb"
 [dependencies]
 chunked_transfer = "1"
 httparse = "1.3.4"
-hyper = { version = "0.14", features = ["http1", "server", "runtime", "tcp", "backports", "deprecated"]}
+http-body-util = "0.1"
+hyper = { version = "1", features = ["http1", "server"]}
+hyper-util = { version = "0.1", features = ["tokio"] }
 log = "0.4"
 rusb = "0.9.4"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "sync", "io-util", "macros", "signal"] }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -4,7 +4,7 @@
 
 use std::convert::Infallible;
 
-use http_body_util::{combinators::BoxBody, BodyExt, Empty};
+use http_body_util::{BodyExt, Empty};
 use hyper::body::Bytes;
 use hyper::http::StatusCode;
 use hyper::server::conn::http1;
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 
 use crate::device::{Connection, Device};
 use crate::error::Error;
-use crate::http::handle_request;
+use crate::http::{handle_request, ResponseBody};
 
 /// Reason for shutting down the proxy.
 ///
@@ -131,9 +131,9 @@ impl Bridge {
         usb: Option<Connection>,
         request: Request<hyper::body::Incoming>,
         handle: AsyncHandle,
-    ) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    ) -> std::result::Result<Response<ResponseBody>, Infallible> {
         if usb.is_none() {
-            let body: Empty<Bytes> = Empty::new();
+            let body = Empty::<Bytes>::new().map_err(|e| match e {});
             return Ok(Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(body.boxed())
@@ -145,7 +145,7 @@ impl Bridge {
             .await
             .or_else(|err| {
                 error!("Request failed: {}", err);
-                let body: Empty<Bytes> = Empty::new();
+                let body = Empty::<Bytes>::new().map_err(|e| match e {});
                 Ok(Response::builder()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(body.boxed())

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -4,10 +4,13 @@
 
 use std::convert::Infallible;
 
+use http_body_util::{combinators::BoxBody, BodyExt, Empty};
+use hyper::body::Bytes;
 use hyper::http::StatusCode;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Body, Request, Response};
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
 use log::{debug, error, info};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Handle as AsyncHandle;
@@ -126,13 +129,14 @@ impl Bridge {
     async fn service_request(
         verbose: bool,
         usb: Option<Connection>,
-        request: Request<Body>,
+        request: Request<hyper::body::Incoming>,
         handle: AsyncHandle,
-    ) -> std::result::Result<Response<Body>, Infallible> {
+    ) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
         if usb.is_none() {
+            let body: Empty<Bytes> = Empty::new();
             return Ok(Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::empty())
+                .body(body.boxed())
                 .unwrap());
         }
         let usb = usb.unwrap();
@@ -141,15 +145,16 @@ impl Bridge {
             .await
             .or_else(|err| {
                 error!("Request failed: {}", err);
+                let body: Empty<Bytes> = Empty::new();
                 Ok(Response::builder()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::empty())
+                    .body(body.boxed())
                     .unwrap())
             })
     }
 
     fn handle_connection(&mut self, stream: TcpStream) {
-        let mut thread_usb = self.usb.clone();
+        let thread_usb = self.usb.clone();
         let verbose = self.verbose_log;
         self.num_clients += 1;
         let client_num = self.num_clients;
@@ -164,8 +169,8 @@ impl Bridge {
                 .preserve_header_case(true)
                 .keep_alive(false)
                 .serve_connection(
-                    stream,
-                    service_fn(move |req| {
+                    TokioIo::new(stream),
+                    service_fn(move |req: Request<hyper::body::Incoming>| {
                         // We would normally want to extract usb_conn and return early if it's an
                         // error, but that doesn't work here because we can't match the return type
                         // of Bridge::service_request.  Instead, convert to an Option and handle a

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -132,14 +132,13 @@ impl Bridge {
         request: Request<hyper::body::Incoming>,
         handle: AsyncHandle,
     ) -> std::result::Result<Response<ResponseBody>, Infallible> {
-        if usb.is_none() {
+        let Some(usb) = usb else {
             let body = Empty::<Bytes>::new().map_err(|e| match e {});
             return Ok(Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(body.boxed())
                 .unwrap());
-        }
-        let usb = usb.unwrap();
+        };
 
         handle_request(verbose, usb, request, handle)
             .await

--- a/src/device.rs
+++ b/src/device.rs
@@ -408,7 +408,7 @@ impl InterfaceManager {
     /// Will block until an interface is available.
     /// If interfaces are currently not claimed, will first set the active device
     /// configuration and re-claim USB interfaces.
-    fn request_interface(&mut self) -> Result<ClaimedInterface> {
+    fn request_interface(&self) -> Result<ClaimedInterface> {
         let mut state = self.state.lock().unwrap();
 
         if state.active == 0 && !state.pending_cleanup {
@@ -432,7 +432,7 @@ impl InterfaceManager {
     }
 
     /// Return an interface to the pool of interfaces.
-    fn free_interface(&mut self, interface: ClaimedInterface) {
+    fn free_interface(&self, interface: ClaimedInterface) {
         debug!(
             "* Returning interface {}",
             interface.descriptor.interface_number
@@ -532,7 +532,7 @@ impl Device {
     ///
     /// The returned interface can be used for I/O with the USB device.  Returns an error if no
     /// IPP-USB interfaces are currently available or if claiming the interface fails.
-    pub fn get_connection(&mut self) -> Result<Connection> {
+    pub fn get_connection(&self) -> Result<Connection> {
         let interface = self.manager.request_interface()?;
         Ok(Connection::new(
             self.verbose_log,

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::Infallible;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::pin::Pin;
@@ -64,6 +63,8 @@ impl fmt::Display for Error {
 }
 
 type Result<T> = std::result::Result<T, Error>;
+pub(crate) type ResponseBody = BoxBody<Bytes, Error>;
+type BodyFrameResult = Result<Frame<Bytes>>;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum BodyLength {
@@ -355,12 +356,12 @@ fn serialize_request_header(
 /// An adapter that implements `hyper::body::Body` over a Tokio MPSC receiver yielding body frames
 /// produced by synchronous USB read tasks.
 struct ResponseBodyStream {
-    rx: Receiver<std::result::Result<Frame<Bytes>, Infallible>>,
+    rx: Receiver<BodyFrameResult>,
 }
 
 impl hyper::body::Body for ResponseBodyStream {
     type Data = Bytes;
-    type Error = Infallible;
+    type Error = Error;
 
     fn poll_frame(
         mut self: Pin<&mut Self>,
@@ -374,7 +375,7 @@ impl hyper::body::Body for ResponseBodyStream {
 // `sender`.
 fn copy_response_body<R: BufRead + Sized>(
     mut response_reader: ResponseReader<R>,
-    sender: &mpsc::Sender<std::result::Result<Frame<Bytes>, Infallible>>,
+    sender: &mpsc::Sender<BodyFrameResult>,
 ) -> Result<usize> {
     let mut reader = match response_reader.body_reader() {
         Ok(r) => r,
@@ -464,7 +465,7 @@ pub(crate) async fn handle_request(
     mut usb: Connection,
     request: hyper::Request<Incoming>,
     handle: AsyncHandle,
-) -> Result<Response<BoxBody<Bytes, Infallible>>> {
+) -> Result<Response<ResponseBody>> {
     info!(
         "Request: {} {} {:?}",
         request.method(),
@@ -574,14 +575,14 @@ pub(crate) async fn handle_request(
     builder = builder.header(header::CONNECTION, "close");
 
     debug!("* Forwarding printer response body");
-    let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+    let (tx, rx) = mpsc::channel::<BodyFrameResult>(2);
     let body = ResponseBodyStream { rx }.boxed();
     handle.spawn_blocking(
         move || match copy_response_body(response_reader, &tx) {
             Ok(num) => debug!("Copied {} bytes of response body", num),
             Err(err) => {
                 error!("Failed to copy response body: {}", err);
-                drop(tx);
+                let _ = tx.blocking_send(Err(err));
             }
         },
     );
@@ -886,7 +887,7 @@ Content-Type: text/plain\r
         assert_eq!(status, StatusCode::OK);
         assert_eq!(headers.len(), 0);
 
-        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let (tx, rx) = mpsc::channel::<BodyFrameResult>(2);
         let body = ResponseBodyStream { rx };
         let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 
@@ -920,7 +921,7 @@ Content-Type: text/plain\r
             "8"
         );
 
-        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let (tx, rx) = mpsc::channel::<BodyFrameResult>(2);
         let body = ResponseBodyStream { rx };
         let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 
@@ -963,7 +964,7 @@ body\r
             "chunked"
         );
 
-        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let (tx, rx) = mpsc::channel::<BodyFrameResult>(2);
         let body = ResponseBodyStream { rx };
         let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,14 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use std::convert::Infallible;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
-use std::thread;
-use std::time::Duration;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use hyper::body::{self, Buf, Bytes, HttpBody};
+use http_body_util::{combinators::BoxBody, BodyExt};
+use hyper::body::{Buf, Bytes, Frame, Incoming};
 use hyper::header::{self, HeaderMap, HeaderName, HeaderValue};
-use hyper::{Body, Method, Response, StatusCode};
+use hyper::{Method, Response, StatusCode};
 use log::{debug, error, info, trace};
 use tokio::runtime::Handle as AsyncHandle;
 use tokio::sync::mpsc::{self, Receiver};
@@ -226,7 +228,7 @@ struct Request {
 // Converts a hyper::Request into our internal Request format.
 // Filter out Hop-by-hop headers and add Content-Length or Transfer-Encoding
 // headers as needed.
-fn rewrite_request(request: &hyper::Request<Body>) -> Request {
+fn rewrite_request<B>(request: &hyper::Request<B>) -> Request {
     let mut headers = HeaderMap::with_capacity(request.headers().len());
     // If the incoming request specifies a Transfer-Encoding, it must be chunked.
     let request_is_chunked = request.headers().contains_key(header::TRANSFER_ENCODING);
@@ -279,7 +281,7 @@ fn rewrite_request(request: &hyper::Request<Body>) -> Request {
     }
 }
 
-fn content_type(request: &hyper::Request<Body>) -> Option<&str> {
+fn content_type<B>(request: &hyper::Request<B>) -> Option<&str> {
     request.headers().get(header::CONTENT_TYPE)?.to_str().ok()
 }
 
@@ -350,11 +352,29 @@ fn serialize_request_header(
     Ok(())
 }
 
+/// An adapter that implements `hyper::body::Body` over a Tokio MPSC receiver yielding body frames
+/// produced by synchronous USB read tasks.
+struct ResponseBodyStream {
+    rx: Receiver<std::result::Result<Frame<Bytes>, Infallible>>,
+}
+
+impl hyper::body::Body for ResponseBodyStream {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
 // Read the response body from `response_reader` in chunks and send them to the client via
 // `sender`.
 fn copy_response_body<R: BufRead + Sized>(
     mut response_reader: ResponseReader<R>,
-    sender: &mut body::Sender,
+    sender: &mpsc::Sender<std::result::Result<Frame<Bytes>, Infallible>>,
 ) -> Result<usize> {
     let mut reader = match response_reader.body_reader() {
         Ok(r) => r,
@@ -378,30 +398,15 @@ fn copy_response_body<R: BufRead + Sized>(
             }
             Ok(num) => {
                 trace!("Read {} bytes from USB", num);
-                let mut to_send = Bytes::copy_from_slice(&buf[0..num]);
-                let mut tries = 10;
-                loop {
-                    match sender.try_send_data(to_send) {
-                        Ok(_) => {
-                            trace!("Sent {} bytes to body channel", num);
-                            copied += num;
-                            break;
-                        }
-                        Err(remaining) => {
-                            error!(
-                                "Tried to send {} bytes.  Body channel did not accept bytes: {}",
-                                num,
-                                remaining.len()
-                            );
-                            // Give the remote side a brief time to read what was previously sent.
-                            thread::sleep(Duration::from_millis(10));
-                            to_send = remaining;
-                            tries -= 1;
-                            if tries == 0 {
-                                error!("Failed to send bytes after 10 tries");
-                                return Err(Error::ResponseBodyTimeout);
-                            }
-                        }
+                let to_send = Bytes::copy_from_slice(&buf[0..num]);
+                match sender.blocking_send(Ok(Frame::data(to_send))) {
+                    Ok(_) => {
+                        trace!("Sent {} bytes to body channel", num);
+                        copied += num;
+                    }
+                    Err(_) => {
+                        error!("Body channel closed by remote client");
+                        return Err(Error::ResponseBodyTimeout);
                     }
                 }
             }
@@ -457,9 +462,9 @@ fn send_request_body<R: Read>(
 pub(crate) async fn handle_request(
     verbose_log: bool,
     mut usb: Connection,
-    request: hyper::Request<Body>,
+    request: hyper::Request<Incoming>,
     handle: AsyncHandle,
-) -> Result<Response<Body>> {
+) -> Result<Response<BoxBody<Bytes, Infallible>>> {
     info!(
         "Request: {} {} {:?}",
         request.method(),
@@ -480,8 +485,11 @@ pub(crate) async fn handle_request(
             // forward the request. If we didn't and the client were to drop in the middle of
             // forwarding a request, we would have no way of cleanly terminating the connection.
             let mut buf = Vec::with_capacity(length);
-            while let Some(chunk) = body.data().await {
-                buf.extend(chunk.map_err(Error::ReadRequestBody)?);
+            while let Some(frame_res) = body.frame().await {
+                let frame = frame_res.map_err(Error::ReadRequestBody)?;
+                if let Ok(chunk) = frame.into_data() {
+                    buf.extend(chunk);
+                }
             }
             Bytes::from(buf)
         }
@@ -489,9 +497,12 @@ pub(crate) async fn handle_request(
             // If we're using chunked, just read enough of the body to have an initial buffer for
             // the loop below.  This is a streaming format, so we don't have any good way to buffer
             // up the exact right amount.
-            match body.data().await {
+            match body.frame().await {
                 None => Err(Error::MalformedRequest),
-                Some(result) => result.map_err(Error::ReadRequestBody),
+                Some(frame_res) => {
+                    let frame = frame_res.map_err(Error::ReadRequestBody)?;
+                    frame.into_data().map_err(|_| Error::MalformedRequest)
+                }
             }?
         }
     };
@@ -517,13 +528,15 @@ pub(crate) async fn handle_request(
             error!("Failed to send request body chunk");
             Error::WriteRequestBody(io::Error::from(io::ErrorKind::UnexpectedEof))
         })?;
-        while let Some(chunk) = body.data().await {
-            let next_buf = chunk.map_err(Error::ReadRequestBody)?;
-            trace!("Copying {} bytes to USB", next_buf.remaining());
-            tx.send(next_buf.reader()).await.map_err(|_| {
-                error!("Failed to send request body chunk");
-                Error::WriteRequestBody(io::Error::from(io::ErrorKind::UnexpectedEof))
-            })?;
+        while let Some(frame_res) = body.frame().await {
+            let frame = frame_res.map_err(Error::ReadRequestBody)?;
+            if let Ok(next_buf) = frame.into_data() {
+                trace!("Copying {} bytes to USB", next_buf.remaining());
+                tx.send(next_buf.reader()).await.map_err(|_| {
+                    error!("Failed to send request body chunk");
+                    Error::WriteRequestBody(io::Error::from(io::ErrorKind::UnexpectedEof))
+                })?;
+            }
         }
         drop(tx); // Close the channel to tell the writer to finish.
         let body_result = body_task.await.map_err(Error::AsyncTaskFailure)?;
@@ -561,13 +574,14 @@ pub(crate) async fn handle_request(
     builder = builder.header(header::CONNECTION, "close");
 
     debug!("* Forwarding printer response body");
-    let (mut sender, body) = Body::channel();
+    let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+    let body = ResponseBodyStream { rx }.boxed();
     handle.spawn_blocking(
-        move || match copy_response_body(response_reader, &mut sender) {
+        move || match copy_response_body(response_reader, &tx) {
             Ok(num) => debug!("Copied {} bytes of response body", num),
             Err(err) => {
                 error!("Failed to copy response body: {}", err);
-                sender.abort();
+                drop(tx);
             }
         },
     );
@@ -627,6 +641,7 @@ fn read_until_delimiter(reader: &mut dyn BufRead, delimiter: &[u8]) -> io::Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::Empty;
     use hyper::Version;
     use std::io::Cursor;
 
@@ -725,7 +740,7 @@ Content-Type: text/plain\r
             .version(Version::HTTP_11)
             .uri("/eSCL/ScannerCapabilities")
             .header("Content-Type", "text/plain")
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
 
         let request_out = rewrite_request(&request_in);
@@ -745,7 +760,7 @@ Content-Type: text/plain\r
             .version(Version::HTTP_11)
             .uri("/eSCL/ScannerCapabilities")
             .header("Content-Length", "4")
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
 
         let request_out = rewrite_request(&request_in);
@@ -765,7 +780,7 @@ Content-Type: text/plain\r
             .version(Version::HTTP_11)
             .uri("/eSCL/ScannerCapabilities")
             .header("Content-Length", format!("{}", CHUNKED_THRESHOLD))
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
 
         let request_out = rewrite_request(&request_in);
@@ -785,7 +800,7 @@ Content-Type: text/plain\r
             .version(Version::HTTP_11)
             .uri("/eSCL/ScannerCapabilities")
             .header("Transfer-Encoding", "chunked")
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
 
         let request_out = rewrite_request(&request_in);
@@ -819,12 +834,12 @@ Content-Type: text/plain\r
 
     #[test]
     fn extract_content_type() {
-        let request = hyper::Request::builder().body(Body::empty()).unwrap();
+        let request = hyper::Request::builder().body(Empty::<Bytes>::new()).unwrap();
         assert!(content_type(&request).is_none());
 
         let request = hyper::Request::builder()
             .header("content-TYPE", "text/html")
-            .body(Body::empty())
+            .body(Empty::<Bytes>::new())
             .unwrap();
         assert!(content_type(&request).is_some());
     }
@@ -871,11 +886,11 @@ Content-Type: text/plain\r
         assert_eq!(status, StatusCode::OK);
         assert_eq!(headers.len(), 0);
 
-        let (mut sender, body) = Body::channel();
-        #[allow(deprecated)]
-        let bytes_task = tokio::spawn(async move { hyper::body::to_bytes(body).await });
+        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let body = ResponseBodyStream { rx };
+        let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 
-        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &mut sender))
+        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &tx))
             .await
             .expect("failed to join copy_response_body task")
             .expect("failed to copy body");
@@ -883,8 +898,7 @@ Content-Type: text/plain\r
 
         let bytes = bytes_task
             .await
-            .expect("failed to join to_bytes task")
-            .expect("failed to read body");
+            .expect("failed to join to_bytes task");
         assert_eq!(bytes, b""[..]);
     }
 
@@ -906,11 +920,11 @@ Content-Type: text/plain\r
             "8"
         );
 
-        let (mut sender, body) = Body::channel();
-        #[allow(deprecated)]
-        let bytes_task = tokio::spawn(async move { hyper::body::to_bytes(body).await });
+        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let body = ResponseBodyStream { rx };
+        let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 
-        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &mut sender))
+        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &tx))
             .await
             .expect("failed to join copy_response_body task")
             .expect("failed to copy body");
@@ -918,8 +932,7 @@ Content-Type: text/plain\r
 
         let bytes = bytes_task
             .await
-            .expect("failed to join to_bytes task")
-            .expect("failed to read body");
+            .expect("failed to join to_bytes task");
         assert_eq!(bytes, b"testbody"[..]);
     }
 
@@ -950,11 +963,11 @@ body\r
             "chunked"
         );
 
-        let (mut sender, body) = Body::channel();
-        #[allow(deprecated)]
-        let bytes_task = tokio::spawn(async move { hyper::body::to_bytes(body).await });
+        let (tx, rx) = mpsc::channel::<std::result::Result<Frame<Bytes>, Infallible>>(2);
+        let body = ResponseBodyStream { rx };
+        let bytes_task = tokio::spawn(async move { body.collect().await.unwrap().to_bytes() });
 
-        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &mut sender))
+        let len = tokio::task::spawn_blocking(move || copy_response_body(reader, &tx))
             .await
             .expect("failed to join copy_response_body task")
             .expect("failed to copy body");
@@ -962,8 +975,7 @@ body\r
 
         let bytes = bytes_task
             .await
-            .expect("failed to join to_bytes task")
-            .expect("failed to read body");
+            .expect("failed to join to_bytes task");
         assert_eq!(bytes, b"testbody"[..]);
     }
 


### PR DESCRIPTION
Changes needed to support API changes from hyper 0.14 to hyper 1.x:

* Replaced the removed `hyper::Server` with TokioIo traits implementation from hyper_util.
* service_fn accepts Fn now instead of FnMut.  This is supported by relying on interior mutability in Device and InterfaceManager.
* The Body struct is now a trait.  ResponseBodyStream provides an implementation of the trait for responses to replace `Body::channel()` and the request reader uses `body::Incoming` directly.
* Replaced `Body::empty()` with `Empty::<Bytes>::new()`.
* Replaced `body.data()` with `body.frame()`.
* Made functions support generic body types instead of `<impl Body>`.

The public API presented by ippusb is unchanged except for loosening Device::get_connection to accept `&self` instead of `&mut self`.

Internally, the behavior WRT to USB traffic should also be unchanged.

Fixes #11.