### PR TITLE
Update version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "ippusb"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chunked_transfer",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ippusb"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The ChromiumOS Authors"]
 edition = "2021"
 rust-version = "1.89"


### PR DESCRIPTION
Switch to new hyper version along with updating other dependencies.

This doesn't change the API.  However, update the minor version since switching to hyper 1.x is non-trivial.
